### PR TITLE
added colored fill to highlight (resolves #10)

### DIFF
--- a/public/planner/js/engine/board.js
+++ b/public/planner/js/engine/board.js
@@ -77,9 +77,14 @@ Board.prototype.showHighlights = function showHighlights(type) {
 
     board.buildings.forEach(function (building) {
         if (board.keepHighlights.indexOf(building.typeGroup) !== -1) {
-            building.moveHighlight(true);
+            building.moveHighlight();
         }
     });
+
+
+
+
+
 };
 
 Board.prototype.hideHighlights = function hideHighlights(type) {
@@ -186,7 +191,8 @@ Board.prototype.buildingsToTop = function buildingsToTop(e) {
         if (b) {
             b.sprite.toBack();
         }
-
+    });
+    this.buildings.forEach(function (b) {
         if (b.highlight) {
             b.highlight.toBack();
         }

--- a/public/planner/js/engine/building.js
+++ b/public/planner/js/engine/building.js
@@ -85,7 +85,7 @@ Building.prototype.drawHighlight = function drawHighlight() {
             stroke: (this.data.highlight.color || '#006600'),
             strokeWidth: 2,
             opacity: 0,
-            fill: 'none',
+            fill: (this.data.highlight.color || '#006600'),
             pointerEvents: 'none'
         });
     }
@@ -106,8 +106,9 @@ Building.prototype.moveHighlight = function moveHighlight(noFill) {
         var highlightY = this.sprite.attr('y') - (this.data.highlight.height / 2 - (this.data.height / 2));
         this.highlight.transform('T'+ highlightX +','+ highlightY);
         this.highlight.attr({
-            fill: (noFill ? 'none' : 'black'),
-            opacity: .4
+            fill: (noFill ? 'none' : (this.data.highlight.color || '#006600')),
+            opacity: .5,
+            "fill-opacity": .75
         });
     }
 };
@@ -121,10 +122,6 @@ Building.prototype.mouseout = function mouseout(e) {
         if (this.board.keepHighlights.indexOf(this.typeGroup) === -1) {
             this.highlight.attr({
                 opacity: 0,
-                fill: 'none'
-            });
-        } else {
-            this.highlight.attr({
                 fill: 'none'
             });
         }


### PR DESCRIPTION
This changes the highlight's behavior to include a fill the same color as the highlight outline, as set in the buildings data file. 

Let me know if you were planning on implementing this differently or there are any adjustments I can make. I also have an alternate branch (alt_fill) that uses a black fill and looks the same as the current behavior when placing the building, if you prefer.