### PR TITLE
Ignore the node-gyp build/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ farms/*.json
 saves/*.xml
 
 *.psd
+
+build/


### PR DESCRIPTION
Commit 4c3a4a21 introduced the `libxmljs` dependency which uses `node-gyp`. The file `build/config.gypi` is generated by `node-gyp`'s "configure" step. Since it is auto-generated, it should probably not be included in the repository.