### PR TITLE
Add image export functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Donations in any sum are very appreciated.
 - [TheLostSoul](https://github.com/TheLostSoul)    
 - [echoenzo](https://github.com/echoenzo)
 - [Ailuridaes](https://github.com/Ailuridaes)
+- [rgson](https://github.com/rgson)
 
 # Integration
 POST `/api/import`     

--- a/public/planner/css/style.css
+++ b/public/planner/css/style.css
@@ -266,6 +266,18 @@ body.dz-drag-hover {
     color: #0f0;
 }
 
+#export-image .export-image-icon {
+    background-color: #730099;
+}
+
+#export-image .export-image-icon:hover {
+    background-color: #9a00cc;
+}
+
+.export-image-icon i {
+    color: #c000ff;
+}
+
 #reset .reset-icon {
     background-color: #900;
 }

--- a/public/planner/index.html
+++ b/public/planner/index.html
@@ -158,6 +158,8 @@
                             <li class="divider"></li>
                             <li id="import"><a class="import-icon" href="#"><i class="fa fa-upload fa-2x side-nav-icon" title="Import from savefile"></i></a></li>
                             <li class="divider"></li>
+                            <li id="export-image"><a class="export-image-icon" href="#"><i class="fa fa-image fa-2x side-nav-icon" title="Export to image file"></i></a></li>
+                            <li class="divider"></li>
                             <li id="reset"><a class="reset-icon" href="#"><i class="fa fa-trash fa-2x side-nav-icon" title="Reset all"></i></a></li>
                         </ul>
                     </section>


### PR DESCRIPTION
This is a first version of an image export functionality which, according to the README, has been requested by the community.

It adds a button between the import and the reset buttons. When clicked, a PNG image of the editor's current state is generated and downloaded.

The image generation code could be moved to a separate file if desired. However, I've initially placed it at one place as I did not want to mess with the project's file structure. Let me know if you'd prefer to have it divided in some way.