### PR TITLE
Reuse board object on loadLayout (resolves #28)

### DIFF
--- a/public/planner/js/main.js
+++ b/public/planner/js/main.js
@@ -78,27 +78,8 @@ $().ready(function () {
     });
 
     function loadLayout (layout) {
-        var oldData = board.exportData();
         showLayoutAlert(layout);
-
-        // clear snapSVG
-        board.R.clear();
-
-        // delete canvas
-        $('#editor').html('');
-
-        // init new board with right sizes
-        board = new Board('#editor', layout.width, layout.height);
-        $('#editor,.editor').css({
-            width: layout.width < 1280 ? 1280 : layout.width,
-            height: layout.height < 1040 ? 1040 : layout.height
-        });
-
         board.loadLayout(layout);
-
-        if (oldData) {
-            board.importData(oldData);
-        }
     }
 
     function showLayoutAlert(layout) {


### PR DESCRIPTION
Keeping the same board object instead of initializing a new one on layout switch fixes the performance drop caused by the buildup of registered event handlers and board objects. See comment on #28.