### PR TITLE
Keep horizontal scrollbar on screen

### DIFF
--- a/public/planner/css/style.css
+++ b/public/planner/css/style.css
@@ -95,7 +95,12 @@ body.dz-drag-hover {
 }
 
 .inner-wrap {
+    max-height: calc(100vh - 45px);
     overflow-x: scroll;
+}
+
+.inner-wrap #waldo-sticky-footer-wrapper {
+    bottom: 15px;
 }
 
 .changelog li {


### PR DESCRIPTION
Rather than at the end of the page. Helps with large farm layouts like IF2R and Capitalist Dream Farm. Had to override the ad code to move it above the scrollbar, so that's a bit ugly.